### PR TITLE
Fixed bug in HTMLParse function

### DIFF
--- a/soup.go
+++ b/soup.go
@@ -50,9 +50,21 @@ func HTMLParse(s string) Root {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if strings.HasPrefix(s, "<!") {
-		return Root{r.FirstChild.NextSibling, r.FirstChild.NextSibling.Data}
+
+	//Navigate to find an html.ElementNode
+	for r.Type != html.ElementNode {
+
+		switch r.Type {
+		case html.DocumentNode:
+			r = r.FirstChild
+		case html.DoctypeNode:
+			r = r.NextSibling
+		case html.CommentNode:
+			r = r.NextSibling
+		}
+
 	}
+
 	return Root{r, r.Data}
 }
 


### PR DESCRIPTION
When it came to parsing an HTML that when started had comments the function fail.

HTML Example

**Note: * == <**

*!DOCTYPE html>
*!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en"> <![endif]-->
*!--[if IE 7]>    <html class="no-js ie7 oldie" lang="en"> <![endif]-->
*!--[if IE 8]>    <html class="no-js ie8 oldie" lang="en"> <![endif]-->
*!--[if gt IE 8]><!-->
*html...