### PR TITLE
Debug mode, check if element is found and correct comments

### DIFF
--- a/soup.go
+++ b/soup.go
@@ -71,9 +71,14 @@ func HTMLParse(s string) Root {
 	defer fetch.CatchPanic("HTMLParse()")
 	r, err := html.Parse(strings.NewReader(s))
 	if err != nil {
-		panic("Unable to parse the HTML")
+		if debug {
+			panic("Unable to parse the HTML")
+		}
+
+		return Root{nil, "", false}
 	}
-	//Navigate to find an html.ElementNode
+
+	// Navigate to find an html.ElementNode
 	for r.Type != html.ElementNode {
 		switch r.Type {
 		case html.DocumentNode:
@@ -113,12 +118,18 @@ func (r Root) FindAll(args ...string) []Root {
 	defer fetch.CatchPanic("FindAll()")
 	temp := fetch.FindAllofem(r.Pointer, args)
 	if len(temp) == 0 {
-		panic("Element `" + args[0] + "` with attributes `" + strings.Join(args[1:], " ") + "` not found")
+		if debug {
+			panic("Element `" + args[0] + "` with attributes `" + strings.Join(args[1:], " ") + "` not found")
+		}
+
+		return []Root{}
 	}
+
 	pointers := make([]Root, 0, 10)
 	for i := 0; i < len(temp); i++ {
 		pointers = append(pointers, Root{temp[i], temp[i].Data, true})
 	}
+
 	return pointers
 }
 
@@ -127,8 +138,13 @@ func (r Root) FindNextSibling() Root {
 	defer fetch.CatchPanic("FindNextSibling()")
 	nextSibling := r.Pointer.NextSibling
 	if nextSibling == nil {
-		panic("No next sibling found")
+		if debug {
+			panic("No next sibling found")
+		}
+
+		return Root{nil, "", false}
 	}
+
 	return Root{nextSibling, nextSibling.Data, true}
 }
 
@@ -137,8 +153,13 @@ func (r Root) FindPrevSibling() Root {
 	defer fetch.CatchPanic("FindPrevSibling()")
 	prevSibling := r.Pointer.PrevSibling
 	if prevSibling == nil {
-		panic("No previous sibling found")
+		if debug {
+			panic("No previous sibling found")
+		}
+
+		return Root{nil, "", false}
 	}
+
 	return Root{prevSibling, prevSibling.Data, true}
 }
 
@@ -148,11 +169,17 @@ func (r Root) FindNextElementSibling() Root {
 	defer fetch.CatchPanic("FindNextElementSibling()")
 	nextSibling := r.Pointer.NextSibling
 	if nextSibling == nil {
-		panic("No next element sibling found")
+		if debug {
+			panic("No next element sibling found")
+		}
+
+		return Root{nil, "", false}
 	}
+
 	if nextSibling.Type == html.ElementNode {
 		return Root{nextSibling, nextSibling.Data, true}
 	}
+
 	p := Root{nextSibling, nextSibling.Data, true}
 	return p.FindNextElementSibling()
 }
@@ -163,11 +190,17 @@ func (r Root) FindPrevElementSibling() Root {
 	defer fetch.CatchPanic("FindPrevElementSibling()")
 	prevSibling := r.Pointer.PrevSibling
 	if prevSibling == nil {
-		panic("No previous element sibling found")
+		if debug {
+			panic("No previous element sibling found")
+		}
+
+		return Root{nil, "", false}
 	}
+
 	if prevSibling.Type == html.ElementNode {
 		return Root{prevSibling, prevSibling.Data, true}
 	}
+
 	p := Root{prevSibling, prevSibling.Data, true}
 	return p.FindPrevElementSibling()
 }
@@ -176,11 +209,17 @@ func (r Root) FindPrevElementSibling() Root {
 func (r Root) Attrs() map[string]string {
 	defer fetch.CatchPanic("Attrs()")
 	if r.Pointer.Type != html.ElementNode {
-		panic("Not an ElementNode")
+		if debug {
+			panic("Not an ElementNode")
+		}
+
+		return nil
 	}
+
 	if len(r.Pointer.Attr) == 0 {
 		return nil
 	}
+
 	return fetch.GetKeyValue(r.Pointer.Attr)
 }
 
@@ -192,21 +231,33 @@ checkNode:
 	if k.Type != html.TextNode {
 		k = k.NextSibling
 		if k == nil {
-			panic("No text node found")
+			if debug {
+				panic("No text node found")
+			}
+
+			return ""
 		}
+
 		goto checkNode
 	}
+
 	if k != nil {
 		r, _ := regexp.Compile(`^\s+$`)
 		if ok := r.MatchString(k.Data); ok {
 			k = k.NextSibling
 			if k == nil {
-				panic("No text node found")
+				if debug {
+					panic("No text node found")
+				}
+
+				return ""
 			}
+
 			goto checkNode
 		}
 		return k.Data
 	}
+
 	return ""
 }
 

--- a/soup.go
+++ b/soup.go
@@ -31,7 +31,7 @@ type Node interface {
 type Root struct {
 	Pointer   *html.Node
 	NodeValue string
-	Found     bool
+	Error     error
 }
 
 var debug = false
@@ -75,7 +75,7 @@ func HTMLParse(s string) Root {
 			panic("Unable to parse the HTML")
 		}
 
-		return Root{nil, "", false}
+		return Root{nil, "", errors.New("Unable to parse the HTML")}
 	}
 
 	// Navigate to find an html.ElementNode
@@ -90,7 +90,7 @@ func HTMLParse(s string) Root {
 		}
 
 	}
-	return Root{r, r.Data, true}
+	return Root{r, r.Data, nil}
 }
 
 // Find finds the first occurrence of the given tag name,
@@ -104,10 +104,10 @@ func (r Root) Find(args ...string) Root {
 			panic("Element `" + args[0] + "` with attributes `" + strings.Join(args[1:], " ") + "` not found")
 		}
 
-		return Root{nil, "", false}
+		return Root{nil, "", errors.New("Element `" + args[0] + "` with attributes `" + strings.Join(args[1:], " ") + "` not found")}
 	}
 
-	return Root{temp, temp.Data, true}
+	return Root{temp, temp.Data, nil}
 }
 
 // FindAll finds all occurrences of the given tag name,
@@ -127,7 +127,7 @@ func (r Root) FindAll(args ...string) []Root {
 
 	pointers := make([]Root, 0, 10)
 	for i := 0; i < len(temp); i++ {
-		pointers = append(pointers, Root{temp[i], temp[i].Data, true})
+		pointers = append(pointers, Root{temp[i], temp[i].Data, nil})
 	}
 
 	return pointers
@@ -142,10 +142,10 @@ func (r Root) FindNextSibling() Root {
 			panic("No next sibling found")
 		}
 
-		return Root{nil, "", false}
+		return Root{nil, "", errors.New("No next sibling found")}
 	}
 
-	return Root{nextSibling, nextSibling.Data, true}
+	return Root{nextSibling, nextSibling.Data, nil}
 }
 
 // FindPrevSibling returns...?
@@ -157,10 +157,10 @@ func (r Root) FindPrevSibling() Root {
 			panic("No previous sibling found")
 		}
 
-		return Root{nil, "", false}
+		return Root{nil, "", errors.New("No previous sibling found")}
 	}
 
-	return Root{prevSibling, prevSibling.Data, true}
+	return Root{prevSibling, prevSibling.Data, nil}
 }
 
 // FindNextElementSibling finds the next element sibling of the pointer in the DOM
@@ -173,14 +173,14 @@ func (r Root) FindNextElementSibling() Root {
 			panic("No next element sibling found")
 		}
 
-		return Root{nil, "", false}
+		return Root{nil, "", errors.New("No next element sibling found")}
 	}
 
 	if nextSibling.Type == html.ElementNode {
-		return Root{nextSibling, nextSibling.Data, true}
+		return Root{nextSibling, nextSibling.Data, nil}
 	}
 
-	p := Root{nextSibling, nextSibling.Data, true}
+	p := Root{nextSibling, nextSibling.Data, nil}
 	return p.FindNextElementSibling()
 }
 
@@ -194,14 +194,14 @@ func (r Root) FindPrevElementSibling() Root {
 			panic("No previous element sibling found")
 		}
 
-		return Root{nil, "", false}
+		return Root{nil, "", errors.New("No previous element sibling found")}
 	}
 
 	if prevSibling.Type == html.ElementNode {
-		return Root{prevSibling, prevSibling.Data, true}
+		return Root{prevSibling, prevSibling.Data, nil}
 	}
 
-	p := Root{prevSibling, prevSibling.Data, true}
+	p := Root{prevSibling, prevSibling.Data, nil}
 	return p.FindPrevElementSibling()
 }
 

--- a/soup.go
+++ b/soup.go
@@ -5,16 +5,17 @@ keeping it as similar as possible to BeautifulSoup
 package soup
 
 import (
+	"errors"
 	"io/ioutil"
 	"net/http"
-	"strings"
-
 	"regexp"
+	"strings"
 
 	"github.com/anaskhan96/soup/fetch"
 	"golang.org/x/net/html"
 )
 
+// Node is...?
 type Node interface {
 	Find(args ...string) Root
 	Attrs() map[string]string
@@ -26,28 +27,46 @@ type Node interface {
 	FindPrevElementSibling() Root
 }
 
+// Root is...?
 type Root struct {
 	Pointer   *html.Node
 	NodeValue string
+	Found     bool
 }
 
-// Returns the HTML returned by the url in string
+var debug = false
+
+// SetDebug set the debug status
+func SetDebug(d bool) {
+	debug = d
+}
+
+// Get returns the HTML returned by the url in string
 func Get(url string) (string, error) {
 	defer fetch.CatchPanic("Get()")
 	resp, err := http.Get(url)
 	if err != nil {
-		panic("Couldn't perform GET request to " + url)
+		if debug {
+			panic("Couldn't perform GET request to " + url)
+		}
+
+		return "", errors.New("Couldn't perform GET request to " + url)
 	}
+
 	defer resp.Body.Close()
 	bytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		panic("Unable to read the response body")
+		if debug {
+			panic("Unable to read the response body")
+		}
+
+		return "", errors.New("Unable to read the response body")
 	}
-	s := string(bytes)
-	return s, nil
+
+	return string(bytes), nil
 }
 
-// Parses the HTML returning a start pointer to the DOM
+// HTMLParse parses the HTML returning a start pointer to the DOM
 func HTMLParse(s string) Root {
 	defer fetch.CatchPanic("HTMLParse()")
 	r, err := html.Parse(strings.NewReader(s))
@@ -66,22 +85,27 @@ func HTMLParse(s string) Root {
 		}
 
 	}
-	return Root{r, r.Data}
+	return Root{r, r.Data, true}
 }
 
-// Finds the first occurrence of the given tag name,
+// Find finds the first occurrence of the given tag name,
 // with or without attribute key and value specified,
 // and returns a struct with a pointer to it
 func (r Root) Find(args ...string) Root {
 	defer fetch.CatchPanic("Find()")
 	temp, ok := fetch.FindOnce(r.Pointer, args, false)
 	if ok == false {
-		panic("Element `" + args[0] + "` with attributes `" + strings.Join(args[1:], " ") + "` not found")
+		if debug {
+			panic("Element `" + args[0] + "` with attributes `" + strings.Join(args[1:], " ") + "` not found")
+		}
+
+		return Root{nil, "", false}
 	}
-	return Root{temp, temp.Data}
+
+	return Root{temp, temp.Data, true}
 }
 
-// Finds all occurrences of the given tag name,
+// FindAll finds all occurrences of the given tag name,
 // with or without key and value specified,
 // and returns an array of structs, each having
 // the respective pointers
@@ -93,30 +117,32 @@ func (r Root) FindAll(args ...string) []Root {
 	}
 	pointers := make([]Root, 0, 10)
 	for i := 0; i < len(temp); i++ {
-		pointers = append(pointers, Root{temp[i], temp[i].Data})
+		pointers = append(pointers, Root{temp[i], temp[i].Data, true})
 	}
 	return pointers
 }
 
+// FindNextSibling returns...?
 func (r Root) FindNextSibling() Root {
 	defer fetch.CatchPanic("FindNextSibling()")
 	nextSibling := r.Pointer.NextSibling
 	if nextSibling == nil {
 		panic("No next sibling found")
 	}
-	return Root{nextSibling, nextSibling.Data}
+	return Root{nextSibling, nextSibling.Data, true}
 }
 
+// FindPrevSibling returns...?
 func (r Root) FindPrevSibling() Root {
 	defer fetch.CatchPanic("FindPrevSibling()")
 	prevSibling := r.Pointer.PrevSibling
 	if prevSibling == nil {
 		panic("No previous sibling found")
 	}
-	return Root{prevSibling, prevSibling.Data}
+	return Root{prevSibling, prevSibling.Data, true}
 }
 
-// Finds the next element sibling of the pointer in the DOM
+// FindNextElementSibling finds the next element sibling of the pointer in the DOM
 // returning a struct with a pointer to it
 func (r Root) FindNextElementSibling() Root {
 	defer fetch.CatchPanic("FindNextElementSibling()")
@@ -125,13 +151,13 @@ func (r Root) FindNextElementSibling() Root {
 		panic("No next element sibling found")
 	}
 	if nextSibling.Type == html.ElementNode {
-		return Root{nextSibling, nextSibling.Data}
+		return Root{nextSibling, nextSibling.Data, true}
 	}
-	p := Root{nextSibling, nextSibling.Data}
+	p := Root{nextSibling, nextSibling.Data, true}
 	return p.FindNextElementSibling()
 }
 
-// Finds the previous element sibling of the pointer in the DOM
+// FindPrevElementSibling finds the previous element sibling of the pointer in the DOM
 // returning a struct with a pointer to it
 func (r Root) FindPrevElementSibling() Root {
 	defer fetch.CatchPanic("FindPrevElementSibling()")
@@ -140,13 +166,13 @@ func (r Root) FindPrevElementSibling() Root {
 		panic("No previous element sibling found")
 	}
 	if prevSibling.Type == html.ElementNode {
-		return Root{prevSibling, prevSibling.Data}
+		return Root{prevSibling, prevSibling.Data, true}
 	}
-	p := Root{prevSibling, prevSibling.Data}
+	p := Root{prevSibling, prevSibling.Data, true}
 	return p.FindPrevElementSibling()
 }
 
-// Returns an array containing key and values of all attributes
+// Attrs returns a map containing all attributes
 func (r Root) Attrs() map[string]string {
 	defer fetch.CatchPanic("Attrs()")
 	if r.Pointer.Type != html.ElementNode {
@@ -158,7 +184,7 @@ func (r Root) Attrs() map[string]string {
 	return fetch.GetKeyValue(r.Pointer.Attr)
 }
 
-// Returns the string inside a non-nested element
+// Text returns the string inside a non-nested element
 func (r Root) Text() string {
 	defer fetch.CatchPanic("Text()")
 	k := r.Pointer.FirstChild


### PR DESCRIPTION
According to #7, with this merge you will be able to:

1. Check if the element is found with the `Error` field in the `Root` struct;
1. Toggle debug mode with the `SetDebug()` function. Default is `false`, if set to `true` will show the various `panic()`.

Example to check if the node is found (no panic will appear in the terminal):

```
source := soup.HTMLParse(resp)
articles := source.Find("section", "class", "loop").FindAll("article")
for _, article := range articles {
	link := article.Find("h2").Find("a")
	if link.Error == nil { // link is an instance of Root
		fmt.Println(link.Text(), "| Link :", link.Attrs()["href"])
	}
}
```

Example to check if the node is found with debug mode (panic will appear in terminal):

```
soup.SetDebug(true)

source := soup.HTMLParse(resp)
articles := source.Find("section", "class", "loop").FindAll("article")
for _, article := range articles {
	link := article.Find("h2").Find("a")
	if link.Error == nil { // link is an instance of Root
		fmt.Println(link.Text(), "| Link :", link.Attrs()["href"])
	}
}
```

Notes:

- I added correct comments to each function, interface and struct. `Node`, `Root`, `FindNextSibling` and `FindPrevSibling` needs edit on their comments.
- The example codes should be updated.