### PR TITLE
Custom headers in Get() request

### DIFF
--- a/soup.go
+++ b/soup.go
@@ -24,15 +24,41 @@ type Root struct {
 
 var debug = false
 
+// Headers contains all HTTP headers to send
+var Headers = make(map[string]string)
+
 // SetDebug sets the debug status
 func SetDebug(d bool) {
 	debug = d
 }
 
+// Header sets a new HTTP header
+func Header(n string, v string) {
+	Headers[n] = v
+}
+
 // Get returns the HTML returned by the url in string
 func Get(url string) (string, error) {
 	defer fetch.CatchPanic("Get()")
-	resp, err := http.Get(url)
+
+	// Init a new HTTP client
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		if debug {
+			panic("Couldn't perform GET request to " + url)
+		}
+
+		return "", errors.New("Couldn't perform GET request to " + url)
+	}
+
+	// Set headers
+	for hName, hValue := range Headers {
+		req.Header.Set(hName, hValue)
+	}
+
+	// Do request
+	resp, err := client.Do(req)
 	if err != nil {
 		if debug {
 			panic("Couldn't perform GET request to " + url)


### PR DESCRIPTION
Fix feature #9.

There are two ways to define a custom header:

1. Via the `Header()` function (suggested if you have to add a few headers);
2. "Massive" add via the `Headers` variable which is an associative array (`map[string]string`).

As always the README needs an edit.

## Examples
Note: all the examples are generated printing the headers received in a PHP page.

### No headers

**Code**
```go
source, _ := soup.Get("http://localhost/headers.php")
fmt.Println(source)
```

**Output**
![No headers](http://i.imgur.com/j6iiUOa.png)

### Headers via Header function

**Code**
```go
soup.Header("Authorization", "Bearer foobar")
source, _ := soup.Get("http://localhost/headers.php")
fmt.Println(source)
```

**Output**
![Header function](http://i.imgur.com/13hDMgZ.png)

### Headers via Headers variable

**Code**
```go
soup.Headers = map[string]string{
	"Authorization": "Bearer foobar",
	"Content-Type": "application/json",
}

source, _ := soup.Get("http://localhost/headers.php")
fmt.Println(source)
```

**Output**
![Headers variable](http://i.imgur.com/0bUCjF8.png)