### PR TITLE
FindStrict and FindAllStrict

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ func Cookie(string, string) // Takes key, value pair to set as cookies to be sen
 func HTMLParse(string) Root // Takes the HTML string as an argument, returns a pointer to the DOM constructed
 func Find([]string) Root // Element tag,(attribute key-value pair) as argument, pointer to first occurence returned
 func FindAll([]string) []Root // Same as Find(), but pointers to all occurrences returned
+func FindStrict([]string) Root //  Element tag,(attribute key-value pair) as argument, pointer to first occurence returned with exact matching values
+func FindAllStrict([]string) []Root // Same as FindStrict(), but pointers to all occurrences returned
 func FindNextSibling() Root // Pointer to the next sibling of the Element in the DOM returned
 func FindNextElementSibling() Root // Pointer to the next element sibling of the Element in the DOM returned
 func FindPrevSibling() Root // Pointer to the previous sibling of the Element in the DOM returned

--- a/soup.go
+++ b/soup.go
@@ -139,7 +139,37 @@ func (r Root) FindAll(args ...string) []Root {
 		}
 		return []Root{}
 	}
-	pointers := make([]Root, 0, 10)
+	pointers := make([]Root, 0, len(temp))
+	for i := 0; i < len(temp); i++ {
+		pointers = append(pointers, Root{temp[i], temp[i].Data, nil})
+	}
+	return pointers
+}
+
+// FindStrict finds the first occurrence of the given tag name
+// only if all provided attribute's values are exists
+func (r Root) FindStrict(args ...string) Root {
+	temp, ok := findOnce(r.Pointer, args, false, true)
+	if ok == false {
+		if debug {
+			panic("Element `" + args[0] + "` with attributes `" + strings.Join(args[1:], " ") + "` not found")
+		}
+		return Root{nil, "", errors.New("element `" + args[0] + "` with attributes `" + strings.Join(args[1:], " ") + "` not found")}
+	}
+	return Root{temp, temp.Data, nil}
+}
+
+// FindAllStrict finds all occurrences of the given tag name
+// only if all provided attribute's values are exists
+func (r Root) FindAllStrict(args ...string) []Root {
+	temp := findAllofem(r.Pointer, args, true)
+	if len(temp) == 0 {
+		if debug {
+			panic("Element `" + args[0] + "` with attributes `" + strings.Join(args[1:], " ") + "` not found")
+		}
+		return []Root{}
+	}
+	pointers := make([]Root, 0, len(temp))
 	for i := 0; i < len(temp); i++ {
 		pointers = append(pointers, Root{temp[i], temp[i].Data, nil})
 	}

--- a/soup.go
+++ b/soup.go
@@ -147,7 +147,7 @@ func (r Root) FindAll(args ...string) []Root {
 }
 
 // FindStrict finds the first occurrence of the given tag name
-// only if all provided attribute's values are exists
+// only if all the values of the provided attribute are an exact match
 func (r Root) FindStrict(args ...string) Root {
 	temp, ok := findOnce(r.Pointer, args, false, true)
 	if ok == false {
@@ -160,7 +160,7 @@ func (r Root) FindStrict(args ...string) Root {
 }
 
 // FindAllStrict finds all occurrences of the given tag name
-// only if all provided attribute's values are exists
+// only if all the values of the provided attribute are an exact match
 func (r Root) FindAllStrict(args ...string) []Root {
 	temp := findAllofem(r.Pointer, args, true)
 	if len(temp) == 0 {
@@ -341,10 +341,14 @@ func findAllofem(n *html.Node, args []string, strict bool) []*html.Node {
 	return nodeLinks
 }
 
+// attributeAndValueEquals reports when the html.Attribute attr has the same attribute name and value as from
+// provided arguments
 func attributeAndValueEquals(attr html.Attribute, attribute, value string) bool {
 	return attr.Key == attribute && attr.Val == value
 }
 
+// attributeContainsValue reports when the html.Attribute attr has the same attribute name as from provided
+// attribute argument and compares if it has the same value in its values parameter
 func attributeContainsValue(attr html.Attribute, attribute, value string) bool {
 	if attr.Key == attribute {
 		for _, attrVal := range strings.Fields(attr.Val) {

--- a/soup_test.go
+++ b/soup_test.go
@@ -44,7 +44,26 @@ const testHTML = `
 </html>
 `
 
+const multipleClassesHTML = `
+<html>
+	<head>
+		<title>Sample Application</title>
+	</head>
+	<body>
+		<div class="first second">Multiple classes</div>
+		<div class="first">Single class</div>
+		<div class="second first third">Multiple classes inorder</div>
+		<div>
+			<div class="first">Inner single class</div>
+			<div class="first second">Inner multiple classes</div>
+			<div class="second first">Inner multiple classes inorder</div>
+		</div>
+	</body>
+</html>
+`
+
 var doc = HTMLParse(testHTML)
+var multipleClasses = HTMLParse(multipleClassesHTML)
 
 func TestFind(t *testing.T) {
 	// Find() and Attrs()
@@ -96,5 +115,27 @@ func TestFindAll(t *testing.T) {
 		if !reflect.DeepEqual(actual, i) {
 			t.Error("Instead of", i, "got", actual)
 		}
+	}
+}
+
+func TestFindAllBySingleClass(t *testing.T) {
+	actual := multipleClasses.FindAll("div", "class", "first")
+	if len(actual) != 6 {
+		t.Errorf("Expected 6 elements to be returned. Actual: %d", len(actual))
+	}
+	actual = multipleClasses.FindAll("div", "class", "third")
+	if len(actual) != 1 {
+		t.Errorf("Expected 1 element to be returned. Actual: %d", len(actual))
+	}
+}
+
+func TestFindBySingleClass(t *testing.T) {
+	actual := multipleClasses.Find("div", "class", "first")
+	if actual.Text() != "Multiple classes" {
+		t.Errorf("Wrong element returned: %s", actual.Text())
+	}
+	actual = multipleClasses.Find("div", "class", "third")
+	if actual.Text() != "Multiple classes inorder" {
+		t.Errorf("Wrong element returned: %s", actual.Text())
 	}
 }

--- a/soup_test.go
+++ b/soup_test.go
@@ -139,3 +139,31 @@ func TestFindBySingleClass(t *testing.T) {
 		t.Errorf("Wrong element returned: %s", actual.Text())
 	}
 }
+
+func TestFindAllStrict(t *testing.T) {
+	actual := multipleClasses.FindAllStrict("div", "class", "first second")
+	if len(actual) != 2 {
+		t.Errorf("Expected 2 elements to be returned. Actual: %d", len(actual))
+	}
+	actual = multipleClasses.FindAllStrict("div", "class", "first third second")
+	if len(actual) != 0 {
+		t.Errorf("0 elements should be returned")
+	}
+
+	actual = multipleClasses.FindAllStrict("div", "class", "second first third")
+	if len(actual) != 1 {
+		t.Errorf("Single item should be returned")
+	}
+}
+
+func TestFindStrict(t *testing.T) {
+	actual := multipleClasses.FindStrict("div", "class", "first")
+	if actual.Text() != "Single class" {
+		t.Errorf("Wrong element returned: %s", actual.Text())
+	}
+
+	actual = multipleClasses.FindStrict("div", "class", "third")
+	if actual.Error == nil {
+		t.Errorf("Element with class \"third\" should not be returned in strict mode")
+	}
+}


### PR DESCRIPTION
Implementation of `FindStrict` and `FindAllStrict` functions based on #15 discussion.
New test scenarios added for this functions and for the old `Find` and `FindAll`  functions.

Also I've implemented a little different algorithm for searching a value occurrence in a tag's attribute values.
In the previous implementation you were searching only for the first occurrence in attribute values:
```go
strings.Fields(n.Attr[i].Val)[0]  == args[2]
```
I've changed this behavior to search in all attribute values:
```go
func attributeContainsValue(attr html.Attribute, attribute, value string) bool {
	if attr.Key == attribute {
		for _, attrVal := range strings.Fields(attr.Val) {
			if attrVal == value {
				return true
			}
		}
	}
	return false
}
```
I think that in this question the order of the value doesn't matter, so there are no difference between `<div class="first second">` and `<div class="second first">` elements.