### PR TITLE
fix nil pointer dereference panic error

### DIFF
--- a/soup.go
+++ b/soup.go
@@ -254,7 +254,7 @@ func (r Root) Attrs() map[string]string {
 func (r Root) Text() string {
 	k := r.Pointer.FirstChild
 checkNode:
-	if k.Type != html.TextNode {
+	if k != nil && k.Type != html.TextNode {
 		k = k.NextSibling
 		if k == nil {
 			if debug {


### PR DESCRIPTION
my code like this
```go
	scripts := doc.FindAll("script", "type", "text/javascript")
	for _, script := range scripts {
		scriptContent = script.Text()
                ...
```
`script.Text()` will cause golang panic when
`<script type="text/javascript" src="/static/bundles/base/zh_CN.js/fa1a0abb4687.js" crossorigin="anonymous"></script>` in html
 
maybe need check k is nil at first


