### PR TITLE
FullText() should not crash when encountering empty node

### DIFF
--- a/soup.go
+++ b/soup.go
@@ -299,6 +299,9 @@ func (r Root) FullText() string {
 
 	var f func(*html.Node)
 	f = func(n *html.Node) {
+		if n == nil {
+			return
+		}
 		if n.Type == html.TextNode {
 			buf.WriteString(n.Data)
 		}

--- a/soup_test.go
+++ b/soup_test.go
@@ -39,7 +39,9 @@ const testHTML = `
     <div id="3">
       <div id="4">Last one</div>
     </div>
-
+    <div id="5">
+        <h1><span></span></h1>
+    </div>
   </body>
 </html>
 `
@@ -182,5 +184,14 @@ func TestFullText(t *testing.T) {
 
 	if li.FullText() != "To a JSP page right?" {
 		t.Errorf("Wrong text: %s", li.FullText())
+	}
+}
+
+func TestFullTextEmpty(t *testing.T) {
+    // <div id="5"><h1><span></span></h1></div>
+    h1 := doc.Find("div", "id", "5").Find("h1")
+
+    if h1.FullText() != "" {
+		t.Errorf("Wrong text: %s", h1.FullText())
 	}
 }


### PR DESCRIPTION
```
--- FAIL: TestFullTextEmpty (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x6463f3]

goroutine 14 [running]:
testing.tRunner.func1(0xc42014eb40)
        /usr/lib/go-1.10/src/testing/testing.go:742 +0x29d
panic(0x68c2e0, 0x8698b0)
        /usr/lib/go-1.10/src/runtime/panic.go:502 +0x229
_/home/swen/Code/soup.Root.FullText.func1(0x0)
        /home/swen/Code/soup/soup.go:302 +0x33
_/home/swen/Code/soup.Root.FullText.func1(0xc420149d50)
        /home/swen/Code/soup/soup.go:306 +0x74
_/home/swen/Code/soup.Root.FullText(0xc420149ce0, 0x6f4198, 0x2, 0x0, 0x0, 0xc42005bf08, 0x1)
        /home/swen/Code/soup/soup.go:313 +0x74
_/home/swen/Code/soup.TestFullTextEmpty(0xc42014eb40)
        /home/swen/Code/soup/soup_test.go:194 +0x1a5
testing.tRunner(0xc42014eb40, 0x6f7a88)
        /usr/lib/go-1.10/src/testing/testing.go:777 +0xd0
created by testing.(*T).Run
        /usr/lib/go-1.10/src/testing/testing.go:824 +0x2e0
exit status 2
```