### PR TITLE
Add defined errors to the package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v1.2
+
+### Added
+
+- ErrorDetails to the Root object. This will contain the templated error messages that used to be returned by Error
+
+## Changed
+
+- Error will now be one of a standard set of errors defined by the package. Details about the error message have been moved
+to the ErrorDetails property of Root.
+
 ## v1.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.2
+## v1.2.0
 
 ### Added
 
@@ -9,7 +9,7 @@
 - Error will now be one of a standard set of errors defined by the package. Details about the error message have been moved
 to the ErrorDetails property of Root.
 
-## v1.1
+## v1.1.0
 
 ### Added
 

--- a/examples/errors/errors.go
+++ b/examples/errors/errors.go
@@ -1,0 +1,33 @@
+// Errors happen. This example shows how to detect and handle some of them.
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/anaskhan96/soup"
+)
+
+func main() {
+	_, err := soup.Get("this url isn't real!")
+	if err != nil && err.(soup.Error).Type == soup.ErrInGetRequest {
+		// Handle as required!
+	}
+
+	url := fmt.Sprintf("https://xkcd.com/50")
+	xkcd, err := soup.Get(url)
+	if err != nil {
+		// Handle it
+	}
+	xkcdSoup := soup.HTMLParse(xkcd)
+	links := xkcdSoup.Find("div", "id", "linkz")
+	if links.Error != nil && links.Error.(soup.Error).Type == soup.ErrElementNotFound {
+		log.Printf("Element not found: %v", links.Error)
+	}
+	// These error types were introduced in version 1.2.0, but just checking for err still works:
+	links = xkcdSoup.Find("div", "id", "links2")
+	if links.Error != nil {
+		log.Printf("Something happened: %s", links.Error)
+	}
+}

--- a/soup.go
+++ b/soup.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/net/html"
 )
 
+// ErrorType defines types of errors that are possible from soup
 type ErrorType int
 
 const (

--- a/soup_test.go
+++ b/soup_test.go
@@ -210,9 +210,6 @@ func TestFullTextEmpty(t *testing.T) {
 	// <div id="5"><h1><span></span></h1></div>
 	h1 := doc.Find("div", "id", "5").Find("h1")
 
-	if h1.Error != nil {
-		assert.Equal(t, ErrElementNotFound, h1.Error.(Error).Type)
-	}
 	if h1.FullText() != "" {
 		t.Errorf("Wrong text: %s", h1.FullText())
 	}

--- a/soup_test.go
+++ b/soup_test.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const testHTML = `
@@ -205,10 +207,27 @@ func TestFullText(t *testing.T) {
 }
 
 func TestFullTextEmpty(t *testing.T) {
-    // <div id="5"><h1><span></span></h1></div>
-    h1 := doc.Find("div", "id", "5").Find("h1")
+	// <div id="5"><h1><span></span></h1></div>
+	h1 := doc.Find("div", "id", "5").Find("h1")
 
-    if h1.FullText() != "" {
+	if h1.Error != nil {
+		assert.Equal(t, ErrElementNotFound, h1.Error.(Error).Type)
+	}
+	if h1.FullText() != "" {
 		t.Errorf("Wrong text: %s", h1.FullText())
 	}
+}
+
+func TestNewErrorReturnsInspectableError(t *testing.T) {
+	err := newError(ErrElementNotFound, "element not found")
+	assert.NotNil(t, err)
+	assert.Equal(t, ErrElementNotFound, err.Type)
+	assert.Equal(t, "element not found", err.Error())
+}
+
+func TestFindReturnsInspectableError(t *testing.T) {
+	r := doc.Find("bogus", "thing")
+	assert.IsType(t, Error{}, r.Error)
+	assert.Equal(t, "element `bogus` with attributes `thing` not found", r.Error.Error())
+	assert.Equal(t, ErrElementNotFound, r.Error.(Error).Type)
 }


### PR DESCRIPTION
Hello! I have finally come back for #29 and solved it basically the way you suggested. I'm looking to try to get involved with more Go OSS and this is my first PR so far.

My biggest concern is that it's theoretically a breaking change, as if someone was depending on having error details in Error previously, those are now gone.

The reason this is so many changes is because as part of adding the ErrorDetails to Root I also changed the usages of Root to use labelled properties rather than specifying everything in each initialization.

Let me know if I should add an example to either the Readme or to the examples folder of this in use?