### PR TITLE
Fix crash in FullText() recursion if one ElementNode has no children (not even TextNode)

### DIFF
--- a/soup.go
+++ b/soup.go
@@ -352,7 +352,7 @@ func (r Root) FullText() string {
 		if n.Type == html.TextNode {
 			buf.WriteString(n.Data)
 		}
-		if n.Type == html.ElementNode {
+		if n.Type == html.ElementNode && n.FirstChild != nil {
 			f(n.FirstChild)
 		}
 		if n.NextSibling != nil {


### PR DESCRIPTION
When calling `FullText()` in an ElementNode which as one ElementNode children with no other nodes inside (not even TextNode, which seems strange but it happens), the recursive function should not continue trying to traverse the first child, as it's `nil`. This pull request handles that case.