### PR TITLE
Filter out non-Element Nodes when doing FindAll

### DIFF
--- a/soup.go
+++ b/soup.go
@@ -404,7 +404,7 @@ func findAllofem(n *html.Node, args []string, strict bool) []*html.Node {
 	var f func(*html.Node, []string, bool)
 	f = func(n *html.Node, args []string, uni bool) {
 		if uni == true {
-			if matchElementName(n, args[0]) {
+			if n.Type == html.ElementNode && matchElementName(n, args[0]) {
 				if len(args) > 1 && len(args) < 4 {
 					for i := 0; i < len(n.Attr); i++ {
 						attr := n.Attr[i]


### PR DESCRIPTION
Running `Root.FindAll("a")` against the following HTML code results in two nodes being returned instead of one. The first one will correctly be the `<a>` element, but the second one will be the `a` text inside of it, which is unexpected and leads to confusing bugs. This issue has already been fixed for the `Root.Find` (`findOnce`) method, but still remains in `Root.FindAll` (`findAllofem`).

```html
<a>a</a>
```