### PR TITLE
fix: correct typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ func PostForm(string, url.Values) {} // Takes the url and body. bodyType is set 
 func Header(string, string) {} // Takes key,value pair to set as headers for the HTTP request made in Get()
 func Cookie(string, string) {} // Takes key, value pair to set as cookies to be sent with the HTTP request in Get()
 func HTMLParse(string) Root {} // Takes the HTML string as an argument, returns a pointer to the DOM constructed
-func Find([]string) Root {} // Element tag,(attribute key-value pair) as argument, pointer to first occurence returned
+func Find([]string) Root {} // Element tag,(attribute key-value pair) as argument, pointer to first occurrence returned
 func FindAll([]string) []Root {} // Same as Find(), but pointers to all occurrences returned
-func FindStrict([]string) Root {} //  Element tag,(attribute key-value pair) as argument, pointer to first occurence returned with exact matching values
+func FindStrict([]string) Root {} //  Element tag,(attribute key-value pair) as argument, pointer to first occurrence returned with exact matching values
 func FindAllStrict([]string) []Root {} // Same as FindStrict(), but pointers to all occurrences returned
 func FindNextSibling() Root {} // Pointer to the next sibling of the Element in the DOM returned
 func FindNextElementSibling() Root {} // Pointer to the next element sibling of the Element in the DOM returned
@@ -37,8 +37,8 @@ func HTML() {} // HTML returns the HTML code for the specific element
 `Root` is a struct, containing three fields :
 * `Pointer` containing the pointer to the current html node
 * `NodeValue` containing the current html node's value, i.e. the tag name for an ElementNode, or the text in case of a TextNode
-* `Error` containing an error in a struct if one occurrs, else `nil` is returned. 
-A detailed text explaination of the error can be accessed using the `Error()` function. A field `Type` in this struct of type `ErrorType` will denote the kind of error that took place, which will consist of either of the following
+* `Error` containing an error in the struct if one occurs, else `nil` is returned. 
+A detailed text explanation of the error can be accessed using the `Error()` function. A field `Type` in this struct of type `ErrorType` will denote the kind of error that took place, which will consist of either of the following
 	* `ErrUnableToParse`
 	* `ErrElementNotFound`
 	* `ErrNoNextSibling`


### PR DESCRIPTION
## Summary

This PR fixes three typos found in the `README.md` file:

1. **"occurence" to "occurrence"** — in the `Find()` and `FindStrict()` function documentation comments
2. **"occurrs" to "occurs"** — in the `Root` struct description
3. **"explaination" to "explanation"** — in the `Root` struct description

These are minor documentation improvements to ensure correctness and readability.