### PR TITLE
docs: prepare the v2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v2.0.0 - 2026-07-27
+
+### Changed
+
+- Go 1.26.5 or newer is now required.
+- Upgraded `golang.org/x/net` to v0.56.0 and `golang.org/x/text` to v0.39.0.
+- Replaced Travis CI with GitHub Actions running tests and a verbose, pinned `govulncheck` scan.
+
+### Security
+
+- Updated the Go toolchain and dependencies to resolve all findings reported by `govulncheck`.
+
 ## v1.2.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # soup
-[![Build Status](https://travis-ci.org/anaskhan96/soup.svg?branch=master)](https://travis-ci.org/anaskhan96/soup)
 [![GoDoc](https://godoc.org/github.com/anaskhan96/soup?status.svg)](https://pkg.go.dev/github.com/anaskhan96/soup)
-[![Go Report Card](https://goreportcard.com/badge/github.com/anaskhan96/soup)](https://goreportcard.com/report/github.com/anaskhan96/soup)
 
 **Web Scraper in Go, similar to BeautifulSoup**
 


### PR DESCRIPTION
## Summary

- remove obsolete Travis CI and Go Report Card badges
- document the Go 1.26.5 compatibility boundary and security upgrades
- add release notes for v2.0.0

## Test plan

- go test ./...
- git diff --check